### PR TITLE
Update global-json.md

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -4,7 +4,7 @@ description: Global.json reference
 keywords: .NET, .NET Core
 author: aL3891
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 09/01/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -14,30 +14,75 @@ ms.assetid: e1ac9659-425f-4486-a376-c12ca942ead8
 
 # Global.json reference
 
-* [projects/sources](#projects)
-* [packages](#packages)
-
-<a name="projects"></a>
 ## projects
 Type: String[]
 
-Specifies what folders the build system should search for projects when resolving dependencies.  The build system will only search top level child folders.
+Specifies which folders the build system should search for projects when resolving dependencies. The build system will only search top-level child folders.
 
-<a name="packages"></a>
+For example:
+
+```json
+{
+    "projects": [ "src", "test" ]
+}
+```
+
 ## packages
-Type: String[]
+Type: String
 
-The folder to store packages.
+The location to store packages.
 
+For example:
+```json
+{
+    "packages": "packages-dir"
+}
+```
 
+## sdk
+Type: Object
 
+Specifies information about the SDK.
 
+### version
+Type: String
 
+The version of the SDK to use.
 
+For example:
 
+```json
+{
+    "sdk": {
+        "version": "1.0.0-preview2-003121"
+    }
+}
+```
 
+### architecture
+Type: String
 
+Specifies which processor architecture to target. Supported values: `x86` or `x64`.
 
+For example:
+```json
+{
+    "sdk": {
+        "architecture": "x86"
+    }
+}
+```
 
+### runtime
+Type: String
 
+Determines which runtime to target. Supported values: `clr` or `coreclr`.
 
+For example:
+```json
+{
+    "sdk": {
+        "runtime": "clr"
+    }
+}
+```


### PR DESCRIPTION
global.json reference was missing entries and examples.

Pending questions:
- Does the packages property work? Or should we add a note about this https://github.com/dotnet/cli/issues/3816?
- What happens if runtime is not specified? 
- What happens if architecture is not specified? 

/cc @blackdwarf @livarcocc